### PR TITLE
Fix: Apply dynamic image path in data.js for GitHub Pages

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -1,10 +1,13 @@
-// 기본 경로 설정
-const relativeBasePath = "../assets/images/";
-const absoluteBasePath = "https://vocochoe.github.io/youtube-clone-fe/assets/images/";
+// ============================
+// 이미지 경로 자동 설정
+// ============================
+const basePath = location.hostname.includes('github.io')
+    ? "https://vocochoe.github.io/youtube-clone-fe/assets/images/"
+    : "../assets/images/";
 
-const basePath = relativeBasePath;
-//const basePath = absoluteBasePath;
-
+// ============================
+// 비디오 데이터
+// ============================
 const videoDataList = [
     {
         id: 1,
@@ -260,7 +263,9 @@ const videoDataList = [
     }
 ];
 
-
+// ============================
+// 구독 채널 데이터
+// ============================
 const subscriptionList = [
     {
         name: "Hello Korea",
@@ -324,7 +329,9 @@ const subscriptionList = [
     }
 ];
 
-
+// ============================
+// 카테고리 데이터
+// ============================
 const categoryList = [
     {name: "전체", active: true},
     {name: "음악"},


### PR DESCRIPTION
- location.hostname에 따라 basePath 자동 설정
  - 로컬 실행 시 ../assets/images/
  - GitHub Pages 실행 시 https://vocochoe.github.io/youtube-clone-fe/assets/images/
- 로컬/배포 환경 호환성 개선